### PR TITLE
Update tailwind.config.js

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
     extend: {
       colors: {
         gray: colors.coolGray,
-        blue: colors.lightBlue,
+        blue: colors.sky,
         red: colors.rose,
         pink: colors.fuchsia,
       },


### PR DESCRIPTION
As of Tailwind CSS v2.2, `lightBlue` has been renamed to `sky`.